### PR TITLE
WIP: Avoid unmount+mount

### DIFF
--- a/src/withAvailableWidth.jsx
+++ b/src/withAvailableWidth.jsx
@@ -36,7 +36,9 @@ export default function withAvailableWidth(
           this._lastKnownContainerWidth) {
           return; // Nothing changed
         }
-        this.setState(INITIAL_STATE);
+        this.setState({
+          availableWidth: this._element.offsetWidth,
+        });
       });
       if (typeof this._unobserve !== 'function') {
         throw new Error(
@@ -50,12 +52,21 @@ export default function withAvailableWidth(
       this._unobserve();
     }
 
+    componentDidUpdate() {
+      if (this._element) {
+        return;
+      }
+      this._element = this._containerElement.childNodes[this._indexInContainer];
+    }
+
     _handleDivRef(domElement) {
       if (!domElement) {
         return;
       }
       this._containerElement = domElement.parentNode;
       this._lastKnownContainerWidth = this._containerElement.offsetWidth;
+      this._indexInContainer = Array.prototype.indexOf.call(
+        this._containerElement.childNodes, domElement);
 
       this.setState({
         availableWidth: domElement.offsetWidth,


### PR DESCRIPTION
Instead of throwing out the child on resize events (which causes state
to be lost) we can use the dom element of the child during the update
phase.

The way we do this is quite complicated, and involves a few tricks:

- On mount, remember the index inside the parent container where we drop
the temporary measuring div.
- On first update, remember the dom node of the wrapped component
- On resize events, compute new width on the memoized child

The downsides are:

- Complexity - this is arguably much trickier than an unmount+mount
- The child component needs to expose a DOM element
- If the order of dom element changes between first render and first
update, we might measure the wrong element
- If the child throws out its child for another one, we're holding on to
the wrong element. This is hard to detect.
- If the child sets a static width based on the available width, the
resize events will never cause any changes to `availableWidth`.

The benefit of this approach is that we won't throw out state for the
child.