### PR TITLE
Use fragments to avoid mount+unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^15.0.0"
+    "react": "^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
@@ -36,9 +36,9 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
     "jest": "^19.0.2",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^16.2.0",
+    "react-addons-test-utils": "^15.6.2",
+    "react-dom": "^16.2.0",
     "resize-observer-polyfill": "^1.4.1",
     "rimraf": "^2.6.1",
     "webpack": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint-plugin-react": "^6.10.3",
     "jest": "^19.0.2",
     "react": "^16.2.0",
-    "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.2.0",
     "resize-observer-polyfill": "^1.4.1",
     "rimraf": "^2.6.1",

--- a/src/__tests__/withAvailableWidth-test.jsx
+++ b/src/__tests__/withAvailableWidth-test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import ReactAddonsTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 
 import withAvailableWidth from '../withAvailableWidth';
 
 it('throws an error if observer does not return a method', () => {
   function render() {
     const Component = withAvailableWidth(() => <div />, () => true);
-    return ReactAddonsTestUtils.renderIntoDocument(<Component />);
+    return ReactTestUtils.renderIntoDocument(<Component />);
   }
   expect(render).toThrowError(/The observer did not provide a way to unobserve/);
 });

--- a/src/test.jsx
+++ b/src/test.jsx
@@ -15,19 +15,30 @@ function resizeObserver(domElement, notify) {
   return () => ro.unobserve(domElement);
 }
 
-function Component({ availableWidth }) {
-  return (
-    <div style={{ width: '100%' }}>
-      <div
-        className="example"
-        style={{
-          width: availableWidth,
-        }}
-      >
-        w={availableWidth}
+class Component extends React.Component {
+  componentDidMount() {
+    console.log('Instance mounted');
+  }
+
+  componentWillUnmount() {
+    console.log('Instance unmounted');
+  }
+
+  render() {
+    const { availableWidth } = this.props;
+    return (
+      <div style={{ width: '100%' }}>
+        <div
+          className="example"
+          style={{
+            width: availableWidth,
+          }}
+        >
+          w={availableWidth}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
 Component.propTypes = {
   availableWidth: PropTypes.number.isRequired,
@@ -44,6 +55,7 @@ function Comparison() {
   );
 }
 
+// eslint-disable-next-line react/no-multi-comp
 class TestApp extends PureComponent {
   constructor() {
     super();

--- a/src/test.jsx
+++ b/src/test.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import React, { PropTypes, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import ResizeObserver from 'resize-observer-polyfill';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3071,10 +3071,6 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-
 react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,9 +1569,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.12"
-  resolved "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -2561,7 +2561,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2772,7 +2772,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -3009,6 +3009,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -3063,28 +3071,27 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
+react-addons-test-utils@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
 
-react-dom@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
-react@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.npmjs.org/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.npmjs.org/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
On my life-long, rainbow-chasing quest to find a solution to the issue
of having to unmount + mount during a resize, I've come up with a new
solution using React 16's new fragment support [1]. Instead of throwing
out the rendered component, we can hide it using an adjacent sibling
selector (.child-a + *). We drop in the measurement div as usual
on mount. But on resize, we inject some css to temporarily hide the
component, then force a new measurement, then re-render the component
with the new width.

Solves the same problem as #5, but in a more elegant/robust way.

The pros:
- No mounting+unmounting of the child

The cons:
- Leaves the measurement div in the DOM, could be confusing (it's
display: none though).
- Uses adjacent sibling selector, which means that this will work best
with nested components with only one child. I tried using a general
sibling selector (.child-a ~ *) but then I risk affecting anything below
the rendered component.
- Makes the code arguably more complex. There's a counter to force the
measurement div to trigger its ref, there's a generated instance id so
that we can dynamically create a <style> tag locally. Hopefully it's all
worth it in the end.

[1] https://reactjs.org/blog/2017/09/26/react-v16.0.html#new-render-return-types-fragments-and-strings